### PR TITLE
Move mocha/chai to devDependencies + remove package-lock from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-package-lock.json

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/the-crazy-88s/js-review-q1/issues"
   },
   "homepage": "https://github.com/the-crazy-88s/js-review-q1#readme",
-  "dependencies": {
+  "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^5.1.1"
   }


### PR DESCRIPTION
### devDependencies ###
Packages related to development (testing in this case) should be in devDependencies instead of dependencies (npm install PACKAGE --save-dev).

More info: https://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies

### package-lock ###
Also removed package-lock.json from .gitignore as this file is intended to be committed.

Terminal output after running npm install:
npm notice created a lockfile as package-lock.json. You should commit this file.

More info: https://stackoverflow.com/questions/44206782/do-i-commit-the-package-lock-json-file-created-by-npm-5